### PR TITLE
Add '--delete' option to sync deploy_cache correctly

### DIFF
--- a/lib/capistrano/s3_archive.rb
+++ b/lib/capistrano/s3_archive.rb
@@ -4,7 +4,7 @@ require "capistrano/s3_archive/version"
 require 'capistrano/scm'
 require 'aws-sdk-core'
 
-set :rsync_options, ['-az']
+set :rsync_options, ['-az --delete']
 set :rsync_copy, "rsync --archive --acls --xattrs"
 set :rsync_cache, "shared/deploy"
 set :local_cache, "tmp/deploy"


### PR DESCRIPTION
Rsync may cause errors when syncing `deploy_cache` directory.