### PR TITLE
Use lockfile to avoid collapsing sources.

### DIFF
--- a/lib/capistrano/s3_archive/version.rb
+++ b/lib/capistrano/s3_archive/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module S3Archive
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
Lock processes during setting up local cache, releasing for each stages.