### PR TITLE
Download S3 object to FileIO object instead of on-memory.

### DIFF
--- a/lib/capistrano/s3_archive.rb
+++ b/lib/capistrano/s3_archive.rb
@@ -24,8 +24,8 @@ module Capistrano
         set :local_cache_dir, "#{fetch(:local_cache)}/#{fetch(:stage)}"
       end
 
-      def get_object
-        s3_client.get_object(bucket: bucket, key: archive_object_key)
+      def get_object(target)
+        s3_client.get_object({ bucket: bucket, key: archive_object_key }, target: target)
       end
 
       def list_objects(all_page = true)
@@ -85,8 +85,7 @@ module Capistrano
             if not File.exist?(archive_file)
               mkdir_p(File.dirname(archive_file))
               File.open(tmp_file, 'w') do |f|
-                content = get_object.body.read
-                f.write(content)
+                get_object(f)
               end
               move(tmp_file, archive_file)
             else

--- a/lib/capistrano/s3_archive/version.rb
+++ b/lib/capistrano/s3_archive/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module S3Archive
-    VERSION = "0.3.4"
+    VERSION = "0.3.5"
   end
 end


### PR DESCRIPTION
`s3.get_object.body.read` download S3 object to on-memory and it may cause slowdown and memory exhausted.